### PR TITLE
Add dropdown, trigger refresh.

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -1,7 +1,7 @@
 /* global TabRecords, VARIATIONS */
 
 // Constants for the survey_answer telemetry probe.
-const SURVEY_IGNORED = 1;
+// const SURVEY_IGNORED = 1;
 const SURVEY_PAGE_FIXED = 2;
 const SURVEY_PAGE_NOT_FIXED = 3;
 
@@ -10,7 +10,7 @@ class Feature {
 
   async configure(studyInfo) {
     let { variation } = studyInfo;
-    browser.browserAction.onClicked.addListener((tab) => this.handleButtonClick(tab.id));
+    browser.runtime.onMessage.addListener(this.onCompatMode);
 
     // The userid will be used to create a unique hash
     // for the etld + userid combination.
@@ -85,6 +85,7 @@ class Feature {
 
       await this.addMainTelemetryData(tabInfo, data, userid);
       if (tabInfo.compatModeWasJustEntered) {
+        tabInfo.compatModeWasJustEntered = false;
         return;
       } else if (tabInfo.payloadWaitingForSurvey) {
         // TODO: change this to send after answering survey
@@ -157,12 +158,13 @@ class Feature {
     }
   }
 
-  handleButtonClick(tabId) {
+  onCompatMode({tabId}) {
     const tabInfo = TabRecords.getOrInsertTabInfo(tabId);
     // TODO: make this refresh and turn on compat mode
     // then show survey
     tabInfo.payloadWaitingForSurvey = Object.assign({}, tabInfo.telemetryPayload);
     tabInfo.compatModeWasJustEntered = true;
+    browser.tabs.reload(tabId);
   }
 
   submitPayloadWaitingForSurvey(tabInfo) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,8 @@
   "browser_action": {
     "browser_style": true,
     "default_icon": "icons/moz-fav-bw-rgb.png",
-    "default_title": "test title"
+    "default_title": "test title",
+    "default_popup": "popup/compatMode.html"
   },
   "experiment_apis": {
     "popupNotification": {
@@ -62,7 +63,7 @@
   "web_accessible_resources": [
     "privileged/pageMonitor/framescript.js"
   ],
-  "permissions": ["management", "storage", "alarms", "webNavigation"],
+  "permissions": ["management", "storage", "alarms", "webNavigation", "tabs"],
   "background": {
     "scripts": ["variations.js", "studySetup.js", "feature.js", "background.js", "tabs.js"]
   }

--- a/src/popup/compatMode.html
+++ b/src/popup/compatMode.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="compatMode.css"/>
+    <script src="compatMode.js" defer></script>
+  </head>
+
+<body>
+  <input id="unbreakCheck" type="checkbox" name="ubreak"/>
+  <label for="unbreak">Unbreak Mode</label>
+  <div> 
+    <p>www.domain.com not working? Turn on Unbreak Mode. This might help if:</p>
+    <ul>
+      <li>Website looks broken or unusual</li>
+      <li>Forms, comments, or widgets not loading</li>
+      <li>Logging in isn’t working</li>
+      <li>Can’t complete a form or transaction</li>
+      <li>Can’t view a video</li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/src/popup/compatMode.js
+++ b/src/popup/compatMode.js
@@ -1,0 +1,15 @@
+function getCurrentWindowActiveTab() {
+  return browser.tabs.query({currentWindow: true, active: true});
+}
+
+const checkbox = document.getElementById("unbreakCheck");
+checkbox.addEventListener("click", (e) => {
+  if (checkbox.checked) {
+    getCurrentWindowActiveTab().then((tabList) => {
+      const activeTabID = tabList[0].id;
+      browser.runtime.sendMessage({tabId: activeTabID});
+    });
+  } else {
+    console.log("unchecking");
+  }
+});


### PR DESCRIPTION
This should open a dropdown on clicking the icon, then after clicking the checkbox, refresh the page and cause a different dropdown to open.

When refreshing the page without this toolbar button click, no dropdowns should open.

Changes to styling will be made once the mocks are finished.
Style and copy changes to the second dropdown will also come in the future.