### PR TITLE
Add multiple banners, send plain-text url if we have permission.

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -40,11 +40,12 @@ telemetry: {
     "attributes": {
       "etld": "f231d141395abf6f4c98dd55fe8c37e2752e82d72e1ffd3b64bdc6c978692fc6",
       "action": "survey_response_fixed",
-      
       // These measurements are untrustworthy, 
       // they will not catch every login form, nor every social script
       "embedded_social_script": "false",
       "login_form_on_page": "false",
+      // This is optional, it will either be a blank string, or a url if the user gives explicit permission.
+      "plain_text_url": "",
       
       // Reporting the status of of prefs we are interested in
       "network_cookie_cookieBehavior": "4",

--- a/src/feature.js
+++ b/src/feature.js
@@ -111,11 +111,14 @@ class Feature {
     // Watch for the user pressing the "Yes this page was fixed"
     // button and record the answer.
     browser.popupNotification.onReportPageFixed.addListener(
-      (tabId) => {
+      (tabId, location) => {
         const tabInfo = TabRecords.getOrInsertTabInfo(tabId);
         if (!tabInfo || !tabInfo.payloadWaitingForSurvey) {
           return;
         }
+        
+        // Location is either an empty string or a URL if the user has given permission.
+        tabInfo.telemetryPayload.plain_text_url = location;
         tabInfo.telemetryPayload.action = SURVEY_PAGE_FIXED;
         this.submitPayloadWaitingForSurvey(tabInfo);
       },

--- a/src/privileged/popupNotification/schema.json
+++ b/src/privileged/popupNotification/schema.json
@@ -20,7 +20,8 @@
         "type": "function",
         "description": "The user clicked 'yes', the page has been fixed.",
         "parameters": [
-          {"type": "integer", "name": "tabId", "minimum": 0}
+          {"type": "integer", "name": "tabId", "minimum": 0},
+          {"type": "string", "name": "location"}
         ]
       },
       {

--- a/src/prompt.css
+++ b/src/prompt.css
@@ -1,8 +1,17 @@
-notification[value="cookie-restrictions-breakage"] {
+notification[value="cookie-restrictions-breakage"],
+notification[value="cookie-restrictions-breakage-report-url"],
+notification[value="cookie-restrictions-breakage-not-fixed"],
+notification[value="cookie-restrictions-breakage-not-sent"],
+notification[value="cookie-restrictions-breakage-thanks"] {
   height: 60px;
   background-color: #FFF !important;
 }
-notification[value="cookie-restrictions-breakage"] .notification-button {
+
+notification[value="cookie-restrictions-breakage"] .notification-button,
+notification[value="cookie-restrictions-breakage-report-url"] .notification-button,
+notification[value="cookie-restrictions-breakage-not-fixed"] .notification-button,
+notification[value="cookie-restrictions-breakage-not-sent"] .notification-button,
+notification[value="cookie-restrictions-breakage-thanks"] .notification-button {
   border: 0 !important;
   border-radius: 2px !important;
   height: 32px;
@@ -10,20 +19,36 @@ notification[value="cookie-restrictions-breakage"] .notification-button {
   background: rgba(12, 12, 13, 0.1) !important;
 }
 
-notification[value="cookie-restrictions-breakage"] .notification-button:hover {
+notification[value="cookie-restrictions-breakage"] .notification-button:hover,
+notification[value="cookie-restrictions-breakage-report-url"] .notification-button:hover,
+notification[value="cookie-restrictions-breakage-not-fixed"] .notification-button:hover,
+notification[value="cookie-restrictions-breakage-not-sent"] .notification-button:hover,
+notification[value="cookie-restrictions-breakage-thanks"] .notification-button:hover {
   background: rgba(12, 12, 13, 0.2) !important;
 }
 
-notification[value="cookie-restrictions-breakage"] .notification-button:active {
+notification[value="cookie-restrictions-breakage"] .notification-button:active,
+notification[value="cookie-restrictions-breakage-report-url"] .notification-button:active,
+notification[value="cookie-restrictions-breakage-not-fixed"] .notification-button:active,
+notification[value="cookie-restrictions-breakage-not-sent"] .notification-button:active,
+notification[value="cookie-restrictions-breakage-thanks"] .notification-button:active {
   background: rgba(12, 12, 13, 0.4) !important;
   color: black !important;
 }
 
-notification[value="cookie-restrictions-breakage"] .messageDetails {
+notification[value="cookie-restrictions-breakage"] .messageDetails,
+notification[value="cookie-restrictions-breakage-report-url"]  .messageDetails,
+notification[value="cookie-restrictions-breakage-not-fixed"] .messageDetails,
+notification[value="cookie-restrictions-breakage-not-sent"] .messageDetails,
+notification[value="cookie-restrictions-breakage-thanks"] .messageDetails {
   margin: 0 150px;
 }
 
-notification[value="cookie-restrictions-breakage"] .messageText {
+notification[value="cookie-restrictions-breakage"] .messageText,
+notification[value="cookie-restrictions-breakage-report-url"] .messageText,
+notification[value="cookie-restrictions-breakage-not-fixed"] .messageText,
+notification[value="cookie-restrictions-breakage-not-sent"] .messageText,
+notification[value="cookie-restrictions-breakage-thanks"] .messageText {
   max-width: 500px;
   font-size: 13px;
 }

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -13,6 +13,7 @@ window.TabRecords = {
       action: "",
       login_form_on_page: false,
       embedded_social_script: false,
+      plain_text_url: "",
       // TODO Possibly remove this later - it may indicate they have previously
       // used compat mode on this page. Or they may have an exception set previuosly.
       // Should we filter users who have previously set exceptions?


### PR DESCRIPTION
Fixes: #22 

Send plain_text_url in telemetry either as a blank string or as the url if we have permission.
Create the rest of the banners, as laid out in 
https://mozilla.invisionapp.com/share/8FPOK53G9ZU#/screens/337500673 