### PR TITLE
Persist banner / Add exceptions.

### DIFF
--- a/src/privileged/pageMonitor/api.js
+++ b/src/privileged/pageMonitor/api.js
@@ -90,7 +90,7 @@ this.pageMonitor = class extends ExtensionAPI {
           try {
             uri = Services.io.newURI(e.data.telemetryData.completeLocation);
             e.data.telemetryData.etld =
-              Services.eTLD.getBaseDomainFromHost(e.data.telemetryData.hostname);
+              Services.eTLD.getBaseDomainFromHost(e.data.telemetryData.origin);
           } catch (error) {
             return;
           }
@@ -107,10 +107,11 @@ this.pageMonitor = class extends ExtensionAPI {
           try {
             uri = Services.io.newURI(e.data.telemetryData.completeLocation);
             e.data.telemetryData.etld =
-              Services.eTLD.getBaseDomainFromHost(e.data.telemetryData.hostname);
+              Services.eTLD.getBaseDomainFromHost(e.data.telemetryData.origin);
           } catch (error) {
             return;
           }
+
           // Browser is never private, so type can always be "trackingprotection"
           e.data.telemetryData.user_has_tracking_protection_exception =
             Services.perms.testExactPermission(uri, "trackingprotection") === Services.perms.ALLOW_ACTION;
@@ -149,14 +150,14 @@ this.pageMonitor = class extends ExtensionAPI {
           AddonManager.addAddonListener(this);
         },
 
-        async addException(currentDomain) {
+        async addException(currenOrigin) {
           const recentWindow = getMostRecentBrowserWindow();
           const tabId = tabTracker.getBrowserTabId(recentWindow.gBrowser.selectedBrowser);
           const hasException = Services.perms.testExactPermissionFromPrincipal(recentWindow.gBrowser.contentPrincipal, "trackingprotection") === Services.perms.ALLOW_ACTION;
           if (!hasException) {
             const addExceptionButton = recentWindow.document.getElementById("tracking-action-unblock");
             addExceptionButton.doCommand();
-            this.extensionSetExceptions.push(currentDomain);
+            this.extensionSetExceptions.push(currenOrigin);
             pageMonitorEventEmitter.emitExceptionSuccessfullyAdded(tabId);
           }
         },

--- a/src/privileged/pageMonitor/framescript.js
+++ b/src/privileged/pageMonitor/framescript.js
@@ -25,7 +25,7 @@ addEventListener("DOMContentLoaded", function(e) {
     return;
   }
 
-  telemetryData.hostname = content.location.hostname;
+  telemetryData.origin = content.location.origin;
   telemetryData.completeLocation = content.location.href;
   // Check if there is a password field on the page, this gives the best
   // indication that this might be a login page

--- a/src/privileged/pageMonitor/schema.json
+++ b/src/privileged/pageMonitor/schema.json
@@ -9,6 +9,13 @@
         "description": "init listeners to listen for changes and errors in the content",
         "async": true,
         "parameters": []
+      },
+      {
+        "name": "addException",
+        "type": "function",
+        "description": "Add a content blocking exception for this domain if it does not exist.",
+        "async": true,
+        "parameters": []
       }
     ],
     "events": [
@@ -46,6 +53,14 @@
           {"type": "string", "name": "error"},
           {"type": "integer", "name": "tabId", "minimum": 0},
           {"type": "boolean", "name": "hasException"}
+        ]
+      },
+      {
+        "name": "onExceptionAdded",
+        "type": "function",
+        "description": "We added an content blocking exception for this page",
+        "parameters": [
+          {"type": "integer", "name": "tabId", "minimum": 0}
         ]
       }
     ]

--- a/src/privileged/pageMonitor/schema.json
+++ b/src/privileged/pageMonitor/schema.json
@@ -18,7 +18,7 @@
         "description": "Add a content blocking exception for this domain if it does not exist.",
         "async": true,
         "parameters": [
-          {"type": "string", "name": "currentDomain"}
+          {"type": "string", "name": "currenOrigin"}
         ]
       }
     ],

--- a/src/privileged/pageMonitor/schema.json
+++ b/src/privileged/pageMonitor/schema.json
@@ -8,14 +8,18 @@
         "type": "function",
         "description": "init listeners to listen for changes and errors in the content",
         "async": true,
-        "parameters": []
+        "parameters": [
+          {"type": "any", "name": "extensionSetExceptions"}
+        ]
       },
       {
         "name": "addException",
         "type": "function",
         "description": "Add a content blocking exception for this domain if it does not exist.",
         "async": true,
-        "parameters": []
+        "parameters": [
+          {"type": "string", "name": "currentDomain"}
+        ]
       }
     ],
     "events": [

--- a/src/privileged/popupNotification/schema.json
+++ b/src/privileged/popupNotification/schema.json
@@ -12,6 +12,13 @@
         "parameters": [
           {"type": "string", "name": "location"}
         ]
+      },
+      {
+        "name": "close",
+        "type": "function",
+        "description": "Close the notification.",
+        "async": true,
+        "parameters": []
       }
     ],
     "events": [

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -62,8 +62,8 @@ window.TabRecords = {
     tabInfo = {
       payloadWaitingForSurvey: null,
       compatModeWasJustEntered: null,
-      currentDomain: null,
-      currentDomainReported: null,
+      currenOrigin: null,
+      currenOriginReported: null,
     };
 
     this._tabs.set(tabId, tabInfo);

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -62,6 +62,8 @@ window.TabRecords = {
     tabInfo = {
       payloadWaitingForSurvey: null,
       compatModeWasJustEntered: null,
+      currentDomain: null,
+      currentDomainReported: null,
     };
 
     this._tabs.set(tabId, tabInfo);


### PR DESCRIPTION
Fixes: #23 

The first banner persists across navigations and refreshes so long as the domain stays the same.

Subsequent banners will disappear, ~I can be convinced otherwise if we want the banner which asks the user to submit the URL to stick around.~ @e-pang approves of this strategy

Fixes: #16 

- Set an exception for the current tab, record the exception in storage
(this is built on top of this PR because I wanted to use currentDomain)

Fixes: #17
- sync the addon localstorage with the chrome code, uninstall from chrome
- remove each exception on uninstall