### PR TITLE
Show the banner upon returning to the same hostname

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -122,12 +122,31 @@ class Feature {
 
       data.completeLocation = null;
       tabInfo.currentOrigin = data.origin;
-      if (tabInfo.currentOrigin !== tabInfo.currentOriginReported) {
-        browser.popupNotification.close();
-      }
-      await this.addMainTelemetryData(tabInfo, data, userid);
 
-      if (tabInfo && tabInfo.payloadWaitingForSurvey && tabInfo.compatModeWasJustEntered) {
+      if (tabInfo.currentOriginReported &&
+          tabInfo.currentOrigin !== tabInfo.currentOriginReported &&
+          !tabInfo.waitingForReturn) {
+        // If the user does not return within 15 min, clear the data, the user has ignored the banner.
+        tabInfo.bannerTimer = setTimeout(function() {
+          tabInfo.payloadWaitingForSurvey = null;
+          tabInfo.currentOriginReported = null;
+          tabInfo.waitingForReturn = null;
+        }, 900000); // 900000 = 15 min
+        browser.popupNotification.close();
+        tabInfo.waitingForReturn = true;
+      } else if (tabInfo &&
+                 tabInfo.currentOrigin === tabInfo.currentOriginReported &&
+                 tabInfo.payloadWaitingForSurvey &&
+                 tabInfo.waitingForReturn) {
+        tabInfo.waitingForReturn = false;
+        window.clearTimeout(tabInfo.bannerTimer);
+        // Show the banner because we have returned to the reported site within 15 min.
+        browser.popupNotification.show(location);
+      }
+
+      // compatModeWasJustEntered - show the banner as a response to clicking the icon.
+      if (tabInfo && tabInfo.compatModeWasJustEntered) {
+        await this.addMainTelemetryData(tabInfo, data, userid);
         tabInfo.compatModeWasJustEntered = false;
         browser.popupNotification.show(location);
       }

--- a/src/privileged/popupNotification/api.js
+++ b/src/privileged/popupNotification/api.js
@@ -63,6 +63,7 @@ class PopupNotificationEventEmitter extends EventEmitter {
     const recentWindow = getMostRecentBrowserWindow();
     const browser = recentWindow.gBrowser.selectedBrowser;
     const tabId = tabTracker.getBrowserTabId(browser);
+    const notificationBox = recentWindow.gBrowser.getNotificationBox();
 
     const userWillSubmit = () => {
       self.emit("page-fixed", tabId, location);
@@ -145,7 +146,6 @@ class PopupNotificationEventEmitter extends EventEmitter {
     };
 
     const label = `Firefox tried to fix the site and reloaded the page. Is ${location} working properly now?`;
-    const notificationBox = recentWindow.gBrowser.getNotificationBox();
     self.cookieRestrictionsBanner = notificationBox.appendNotification(
       label, // message
       "cookie-restrictions-breakage", // value

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -62,6 +62,8 @@ window.TabRecords = {
       compatModeWasJustEntered: null,
       currentOrigin: null,
       currentOriginReported: null,
+      bannerTimer: null,
+      waitingForReturn: null,
     };
 
     this._tabs.set(tabId, tabInfo);


### PR DESCRIPTION
Fixes: #33 

Hide the banner if:
- currentOriginReported is not null (otherwise nothing has been reported). 
- currentOrigin and tabInfo.currentOriginReported are not equal (user has navigated away)
- the banner wasn't already closed.
then set a 15 min timeout to clear all the data.

If the user returns to the same domain within the 15 min.
- open the banner
- clear the timeout