### PR TITLE
Check and set permissions correctly for non-https websites.

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -293,7 +293,7 @@ class Feature {
     };
 
     tabInfo.compatModeWasJustEntered = true;
-    browser.pageMonitor.addException(tabInfo.currentOrigin);
+    browser.pageMonitor.addException();
     browser.tabs.reload(tabId);
   }
 

--- a/src/privileged/pageMonitor/schema.json
+++ b/src/privileged/pageMonitor/schema.json
@@ -17,9 +17,7 @@
         "type": "function",
         "description": "Add a content blocking exception for this domain if it does not exist.",
         "async": true,
-        "parameters": [
-          {"type": "string", "name": "currentOrigin"}
-        ]
+        "parameters": []
       },
       {
         "name": "testPermission",


### PR DESCRIPTION
Fixes #63 

non-https sites were not working correctly, since the exception is being forced to store the address as "https", but we were checking and saving the non-https version.